### PR TITLE
Provide pulumi-svmkit support for svmkit firewall component

### DIFF
--- a/provider/pkg/firewall/defaults.go
+++ b/provider/pkg/firewall/defaults.go
@@ -1,0 +1,32 @@
+package firewall
+
+import (
+	"context"
+
+	"github.com/abklabs/svmkit/pkg/firewall"
+)
+
+type FirewallParamsInput struct {
+	Variant firewall.FirewallVariant `pulumi:"variant"`
+}
+
+type FirewallParamsOutput struct {
+	FirewallParamsInput
+	firewall.FirewallParams
+}
+
+type GetDefaultFirewallParams struct{}
+
+func (GetDefaultFirewallParams) Call(ctx context.Context, input FirewallParamsInput) (FirewallParamsOutput, error) {
+	params, err := firewall.GetDefaultFirewallParams([]firewall.FirewallVariant{input.Variant}...)
+	if err != nil {
+		return FirewallParamsOutput{}, err
+	}
+
+	output := FirewallParamsOutput{
+		FirewallParamsInput: input,
+		FirewallParams:      *params,
+	}
+
+	return output, nil
+}

--- a/provider/pkg/firewall/firewall.go
+++ b/provider/pkg/firewall/firewall.go
@@ -1,0 +1,85 @@
+package firewall
+
+import (
+	"context"
+
+	"github.com/abklabs/pulumi-svmkit/pkg/utils"
+	"github.com/abklabs/svmkit/pkg/firewall"
+)
+
+// Firewall represents a Pulumi resource for managing an Firewall.
+type Firewall struct{}
+
+// FirewallArgs represents the input arguments required to create an Firewall resource.
+type FirewallArgs struct {
+	utils.RunnerArgs
+	firewall.Firewall
+}
+
+// FirewallState represents the state of an Firewall resource.
+type FirewallState struct {
+	FirewallArgs
+}
+
+// Create is the method that Pulumi calls to create an Firewall resource.
+// It sets up the Firewall on the specified machine using the provided connection and flags.
+//
+// Parameters:
+// - ctx: The context for the creation operation.
+// - name: The name of the resource.
+// - input: The input arguments for creating the resource.
+// - preview: A boolean indicating whether this is a preview operation.
+//
+// Returns:
+// - The name of the created resource.
+// - The state of the created resource.
+// - An error if the creation fails.
+func (Firewall) Create(ctx context.Context, name string, input FirewallArgs, preview bool) (string, FirewallState, error) {
+	state := FirewallState{FirewallArgs: input}
+
+	if preview {
+		return name, state, nil
+	}
+
+	inputFirewall := input.Firewall
+
+	command := inputFirewall.Create()
+
+	if err := utils.RunnerHelper(ctx, input.RunnerArgs, command); err != nil {
+		return "", FirewallState{}, err
+	}
+
+	return name, state, nil
+}
+
+// Update is the method that Pulumi calls to update an Firewall resource.
+// It sets up the Firewall validator on the specified machine using the provided connection and flags.
+//
+// Parameters:
+// - ctx: The context for the update operation.
+// - name: The name of the resource.
+// - oldInput: The previous input arguments for the resource.
+// - newInput: The new input arguments for updating the resource.
+// - preview: A boolean indicating whether this is a preview operation.
+//
+// Returns:
+// - The name of the updated resource.
+// - The state of the updated resource.
+// - An error if the update fails.
+func (Firewall) Update(ctx context.Context, name string, oldInput, newInput FirewallArgs, preview bool) (string, FirewallState, error) {
+	state := FirewallState{FirewallArgs: newInput}
+
+	if preview {
+		return name, state, nil
+	}
+
+	inputFirewall := newInput.Firewall
+
+	command := inputFirewall.Create()
+
+	if err := utils.RunnerHelper(ctx, newInput.RunnerArgs, command); err != nil {
+		return "", FirewallState{}, err
+	}
+
+	return name, state, nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/abklabs/pulumi-svmkit/pkg/networkinfo"
 	"github.com/abklabs/pulumi-svmkit/pkg/svm"
 	"github.com/abklabs/pulumi-svmkit/pkg/tuner"
+	"github.com/abklabs/pulumi-svmkit/pkg/firewall"
 	"github.com/abklabs/pulumi-svmkit/pkg/validator"
 	"github.com/abklabs/pulumi-svmkit/pkg/watchtower"
 	p "github.com/pulumi/pulumi-go-provider"
@@ -79,6 +80,7 @@ func Provider() p.Provider {
 			infer.Resource[faucet.Faucet, faucet.FaucetArgs, faucet.FaucetState](),
 			infer.Resource[explorer.Explorer, explorer.ExplorerArgs, explorer.ExplorerState](),
 			infer.Resource[tuner.Tuner, tuner.TunerArgs, tuner.TunerState](),
+			infer.Resource[firewall.Firewall, firewall.FirewallArgs, firewall.FirewallState](),			 
 			infer.Resource[watchtower.Watchtower, watchtower.WatchtowerArgs, watchtower.WatchtowerState](),
 			infer.Resource[genesis.Solana, genesis.SolanaArgs, genesis.SolanaState](),
 			infer.Resource[account.VoteAccount, account.VoteAccountArgs, account.VoteAccountState](),
@@ -89,6 +91,7 @@ func Provider() p.Provider {
 		Functions: []infer.InferredFunction{
 			infer.Function[networkinfo.GetNetworkInfo, networkinfo.GetNetworkInfoInput, networkinfo.GetNetworkInfoOutput](),
 			infer.Function[tuner.GetDefaultTunerParams, tuner.TunerParamsInput, tuner.TunerParamsOutput](),
+			infer.Function[firewall.GetDefaultFirewallParams, firewall.FirewallParamsInput, firewall.FirewallParamsOutput](),
 		},
 		ModuleMap: map[tokens.ModuleName]tokens.ModuleName{
 			"svm": "index",


### PR DESCRIPTION
Added support for svmkit firewall component. 
Removes need to configure firewall in other components like agave and faucet.
